### PR TITLE
build(deps): bump jgit dependency to latest 6.x version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 jspecify = "1.0.0"
 jetbrains-annotations = "26.0.2"
-jgit = "6.7.0.202309050840-r"
+jgit = "6.10.1.202505221210-r"
 # Gradle-specific
 gradle-licenser = "3.0.1+"
 gradle-plugin-publish = "2.0.0"


### PR DESCRIPTION
Current 6.7.0 version has a minor XXE vulnerability, fixed in 6.10.1: https://projects.eclipse.org/projects/technology.jgit/releases/6.10.1

v7 requires Java 17 (which seems OK for this project), but has some other breaking API changes so I've just moved to the latest 6.x release here.

https://projects.eclipse.org/projects/technology.jgit
https://projects.eclipse.org/projects/technology.jgit/releases/7.0.0